### PR TITLE
Add candlestick chart with expanded dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 ## Giới thiệu
-Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng web viết bằng PHP.
+Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng web viết bằng PHP hiển thị biểu đồ nến (candlestick) cho dữ liệu chứng khoán demo.
 
 ## Yêu cầu
 - PHP >= 7.4
@@ -16,9 +16,13 @@ Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng w
 3. Truy cập `http://localhost:8000` để xem ứng dụng.
 
 ## Thư viện
-Hiện tại dự án không sử dụng bất kỳ thư viện bên ngoài nào.
-=======
-Ứng dụng đơn giản hiển thị biểu đồ chứng khoán với dữ liệu demo sử dụng Chart.js.
+Ứng dụng sử dụng các thư viện:
+
+- [Chart.js](https://www.chartjs.org/)
+- [chartjs-chart-financial](https://github.com/chartjs/chartjs-chart-financial)
+- [Luxon](https://moment.github.io/luxon/)
+
+Biểu đồ hiển thị dữ liệu chứng khoán mẫu với nhiều điểm dữ liệu hơn.
 
 ## Chạy
 

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Biểu đồ chứng khoán demo</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/luxon@3/build/global/luxon.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-financial@4"></script>
 </head>
 <body>
     <h1>Biểu đồ chứng khoán demo</h1>
@@ -11,29 +14,35 @@
     <script>
         const ctx = document.getElementById('stockChart').getContext('2d');
 
-        // Dữ liệu giá cổ phiếu demo
-        const labels = ['Thứ 2', 'Thứ 3', 'Thứ 4', 'Thứ 5', 'Thứ 6'];
-        const data = [100, 102, 101, 105, 110];
+        // Dữ liệu giá cổ phiếu demo với định dạng OHLC
+        const data = [
+            { x: '2023-10-02', o: 100, h: 110, l: 95, c: 108 },
+            { x: '2023-10-03', o: 108, h: 112, l: 104, c: 110 },
+            { x: '2023-10-04', o: 110, h: 115, l: 107, c: 112 },
+            { x: '2023-10-05', o: 112, h: 118, l: 110, c: 116 },
+            { x: '2023-10-06', o: 116, h: 120, l: 114, c: 118 },
+            { x: '2023-10-09', o: 118, h: 122, l: 116, c: 120 },
+            { x: '2023-10-10', o: 120, h: 125, l: 119, c: 123 },
+            { x: '2023-10-11', o: 123, h: 130, l: 121, c: 128 },
+            { x: '2023-10-12', o: 128, h: 132, l: 126, c: 130 },
+            { x: '2023-10-13', o: 130, h: 135, l: 128, c: 133 }
+        ];
 
         new Chart(ctx, {
-            type: 'line',
+            type: 'candlestick',
             data: {
-                labels: labels,
                 datasets: [{
                     label: 'Giá (USD)',
-                    data: data,
-                    borderColor: 'rgba(75, 192, 192, 1)',
-                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                    tension: 0.1
+                    data: data
                 }]
             },
             options: {
                 scales: {
                     x: {
-                        display: true
-                    },
-                    y: {
-                        display: true
+                        type: 'time',
+                        time: {
+                            unit: 'day'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Display stock data as a candlestick chart using Chart.js financial plugin
- Expand demo dataset and load necessary libraries
- Document library usage and chart type in README

## Testing
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7e71739f88321a1442475e218d14a