### PR TITLE
feat: add stock data fetch module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # web_ck_php
 
-
 ## Giới thiệu
-Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng web viết bằng PHP hiển thị biểu đồ nến (candlestick) cho dữ liệu chứng khoán demo.
+Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng web viết bằng PHP hiển thị biểu đồ nến (candlestick) cho dữ liệu chứng khoán.
 
 ## Yêu cầu
 - PHP >= 7.4
@@ -15,6 +14,9 @@ Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng w
    ```
 3. Truy cập `http://localhost:8000` để xem ứng dụng.
 
+## Lấy dữ liệu chứng khoán
+Endpoint `public/fetch_stock.php` sử dụng API của Alpha Vantage (khóa `demo`) để tải dữ liệu giá cổ phiếu hằng ngày. Có thể truyền mã cổ phiếu bằng tham số `symbol`, ví dụ `fetch_stock.php?symbol=IBM`. Trang `index.php` sẽ gọi endpoint này để hiển thị biểu đồ.
+
 ## Thư viện
 Ứng dụng sử dụng các thư viện:
 
@@ -22,14 +24,5 @@ Dự án `web_ck_php` cung cấp một ví dụ tối giản về ứng dụng w
 - [chartjs-chart-financial](https://github.com/chartjs/chartjs-chart-financial)
 - [Luxon](https://moment.github.io/luxon/)
 
-Biểu đồ hiển thị dữ liệu chứng khoán mẫu với nhiều điểm dữ liệu hơn.
+Biểu đồ hiển thị dữ liệu chứng khoán với nhiều điểm dữ liệu.
 
-## Chạy
-
-Sử dụng máy chủ PHP tích hợp:
-
-```bash
-php -S localhost:8000 -t public
-```
-
-Sau đó truy cập vào [http://localhost:8000](http://localhost:8000) để xem biểu đồ.

--- a/public/fetch_stock.php
+++ b/public/fetch_stock.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+
+$symbol = isset($_GET['symbol']) ? strtoupper($_GET['symbol']) : 'IBM';
+$apiKey = 'demo';
+
+$url = sprintf('https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=%s&apikey=%s', urlencode($symbol), $apiKey);
+
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$raw = curl_exec($ch);
+if ($raw === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Unable to fetch data']);
+    exit;
+}
+curl_close($ch);
+
+$json = json_decode($raw, true);
+if (!isset($json['Time Series (Daily)'])) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Invalid API response']);
+    exit;
+}
+
+$data = [];
+foreach (array_slice($json['Time Series (Daily)'], 0, 30) as $date => $values) {
+    $data[] = [
+        'x' => $date,
+        'o' => (float) $values['1. open'],
+        'h' => (float) $values['2. high'],
+        'l' => (float) $values['3. low'],
+        'c' => (float) $values['4. close'],
+    ];
+}
+
+echo json_encode($data);
+

--- a/public/index.php
+++ b/public/index.php
@@ -14,39 +14,33 @@
     <script>
         const ctx = document.getElementById('stockChart').getContext('2d');
 
-        // Dữ liệu giá cổ phiếu demo với định dạng OHLC
-        const data = [
-            { x: '2023-10-02', o: 100, h: 110, l: 95, c: 108 },
-            { x: '2023-10-03', o: 108, h: 112, l: 104, c: 110 },
-            { x: '2023-10-04', o: 110, h: 115, l: 107, c: 112 },
-            { x: '2023-10-05', o: 112, h: 118, l: 110, c: 116 },
-            { x: '2023-10-06', o: 116, h: 120, l: 114, c: 118 },
-            { x: '2023-10-09', o: 118, h: 122, l: 116, c: 120 },
-            { x: '2023-10-10', o: 120, h: 125, l: 119, c: 123 },
-            { x: '2023-10-11', o: 123, h: 130, l: 121, c: 128 },
-            { x: '2023-10-12', o: 128, h: 132, l: 126, c: 130 },
-            { x: '2023-10-13', o: 130, h: 135, l: 128, c: 133 }
-        ];
-
-        new Chart(ctx, {
-            type: 'candlestick',
-            data: {
-                datasets: [{
-                    label: 'Giá (USD)',
-                    data: data
-                }]
-            },
-            options: {
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: {
-                            unit: 'day'
+        fetch('fetch_stock.php?symbol=IBM')
+            .then(response => response.json())
+            .then(data => {
+                new Chart(ctx, {
+                    type: 'candlestick',
+                    data: {
+                        datasets: [{
+                            label: 'Giá IBM (USD)',
+                            data: data
+                        }]
+                    },
+                    options: {
+                        scales: {
+                            x: {
+                                type: 'time',
+                                time: {
+                                    unit: 'day'
+                                }
+                            }
                         }
                     }
-                }
-            }
-        });
+                });
+            })
+            .catch(error => {
+                console.error('Error loading data', error);
+            });
     </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add PHP endpoint to download stock prices from Alpha Vantage
- load fetched data in candlestick chart
- document usage of the new stock data module

## Testing
- `php -l public/fetch_stock.php`
- `php -l public/index.php`
- `php public/fetch_stock.php | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68a7e8772f408321abff460e8733d91e